### PR TITLE
Update download_abide_preproc.py

### DIFF
--- a/download_abide_preproc.py
+++ b/download_abide_preproc.py
@@ -10,7 +10,7 @@ directory; users specify derivative, pipeline, strategy, and optionally
 age ranges, sex, site of interest
 
 Usage:
-    python download_abide_preproc.py -d <derivative> -p <pipeline>
+    python3 download_abide_preproc.py -d <derivative> -p <pipeline>
                                      -s <strategy> -o <out_dir>
                                      [-lt <less_than>] [-gt <greater_than>]
                                      [-x <sex>] [-t <site>]


### PR DESCRIPTION
I just updated the header notes for how to run this script. Since the script uses urllib and therefore (perhaps among other reasons) requires Python3, I believe the command `python3` is required in the terminal rather than typing `python`. At least that's the experience I had on my Mac